### PR TITLE
Extend Accelerate BLAS constraint to all macOS

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - dask
     - geff
   run_constrained:
-    - libblas * *newaccelerate  # [osx and arm64]
+    - libblas * *newaccelerate  # [osx]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
   entry_points:
     - trackastra = trackastra.cli:cli
 


### PR DESCRIPTION
## Summary
- Change `run_constrained` selector from `# [osx and arm64]` to `# [osx]` so Intel Macs also get Apple Accelerate BLAS

Builds on #6 — should be merged after that PR.

## Context
The `newaccelerate` libblas variant exists for both `osx-64` and `osx-arm64`. Intel Macs have the same OpenBLAS default and benefit from Accelerate too. PyTorch on conda-forge (even latest 2.9.1) doesn't pin a BLAS variant, so the default remains OpenBLAS unless constrained.

## Test plan
- [ ] Verify CI passes on all platforms
- [ ] Verify `conda create -n test trackastra` on osx-64 resolves `libblas * *newaccelerate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)